### PR TITLE
add http connection timeout config for ec2 and s3 clients

### DIFF
--- a/examples/config-map.yaml
+++ b/examples/config-map.yaml
@@ -18,7 +18,8 @@ data:
       "ManagementSubnet": "subnet-bad5ede0febe6dd",
       "ClusterName": "aws-virtual-kubelet",
       "Region": "us-west-2",
-      "awsClientTimeoutSeconds":30
+      "awsClientTimeoutSeconds":10
+      "AWSClientDialerTimeoutSeconds":2
       "VMConfig": {
         "DefaultAMI": "ami-badf005ba117ab1e5",
         "InitData": "base64encoded"

--- a/examples/config-map.yaml
+++ b/examples/config-map.yaml
@@ -18,6 +18,7 @@ data:
       "ManagementSubnet": "subnet-bad5ede0febe6dd",
       "ClusterName": "aws-virtual-kubelet",
       "Region": "us-west-2",
+      "awsClientTimeoutSeconds":30
       "VMConfig": {
         "DefaultAMI": "ami-badf005ba117ab1e5",
         "InitData": "base64encoded"

--- a/examples/config-map.yaml
+++ b/examples/config-map.yaml
@@ -18,7 +18,7 @@ data:
       "ManagementSubnet": "subnet-bad5ede0febe6dd",
       "ClusterName": "aws-virtual-kubelet",
       "Region": "us-west-2",
-      "awsClientTimeoutSeconds":10
+      "AWSClientTimeoutSeconds":10
       "AWSClientDialerTimeoutSeconds":2
       "VMConfig": {
         "DefaultAMI": "ami-badf005ba117ab1e5",

--- a/internal/awsutils/ec2_client.go
+++ b/internal/awsutils/ec2_client.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
-
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	vkconfig "github.com/aws/aws-virtual-kubelet/internal/config"
 	"k8s.io/klog"
 )
 
@@ -28,9 +28,10 @@ type Client struct {
 }
 
 // NewEc2Client creates a new AWS client in the given region.
-func NewEc2Client(clientTimeoutSeconds int) (*Client, error) {
+func NewEc2Client() (*Client, error) {
 	// Initialize client session configuration.
-	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(clientTimeoutSeconds))
+	vkcfg := vkconfig.Config()
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.HealthCheckIntervalSeconds))
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)

--- a/internal/awsutils/ec2_client.go
+++ b/internal/awsutils/ec2_client.go
@@ -31,7 +31,7 @@ type Client struct {
 func NewEc2Client() (*Client, error) {
 	// Initialize client session configuration.
 	vkcfg := vkconfig.Config()
-	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.HealthCheckIntervalSeconds))
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds))
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)

--- a/internal/awsutils/ec2_client.go
+++ b/internal/awsutils/ec2_client.go
@@ -12,6 +12,7 @@ package awsutils
 import (
 	"context"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -30,8 +31,14 @@ type Client struct {
 // NewEc2Client creates a new AWS client in the given region.
 func NewEc2Client() (*Client, error) {
 	// Initialize client session configuration.
+	//TODO Ideally we should set overall timeout for API, refer to below documentation
+	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/custom-http/
+	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
 	vkcfg := vkconfig.Config()
-	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds))
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds)).WithDialerOptions(func(d *net.Dialer) {
+		d.KeepAlive = -1
+		d.Timeout = time.Second * time.Duration(vkcfg.AWSClientDialerTimeoutSeconds)
+	})
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)

--- a/internal/awsutils/ec2_client.go
+++ b/internal/awsutils/ec2_client.go
@@ -14,6 +14,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
+
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"k8s.io/klog"
@@ -26,9 +28,10 @@ type Client struct {
 }
 
 // NewEc2Client creates a new AWS client in the given region.
-func NewEc2Client(region string) (*Client, error) {
+func NewEc2Client(clientTimeoutSeconds int) (*Client, error) {
 	// Initialize client session configuration.
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(clientTimeoutSeconds))
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)
 		return nil, errors.New("unable to find load SDK config : ")

--- a/internal/awsutils/ec2_client.go
+++ b/internal/awsutils/ec2_client.go
@@ -31,9 +31,9 @@ type Client struct {
 // NewEc2Client creates a new AWS client in the given region.
 func NewEc2Client() (*Client, error) {
 	// Initialize client session configuration.
-	//TODO Ideally we should set overall timeout for API, refer to below documentation
-	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/custom-http/
-	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
+	// See the following links for an explanation of the timeout options
+	// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/custom-http/
+	// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
 	vkcfg := vkconfig.Config()
 	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds)).WithDialerOptions(func(d *net.Dialer) {
 		d.KeepAlive = -1

--- a/internal/awsutils/ec2_client_utils.go
+++ b/internal/awsutils/ec2_client_utils.go
@@ -98,7 +98,7 @@ func EC2RunInstancesUtil(
 //  userdata: base 64 encoded string with presigned URL to download and initialize the bootstrap agent
 //  err: any error that might occur as part of attempting to generate UserData
 func GenerateVKVMUserData(ctx context.Context, clientTimeoutSeconds int, bootstrapS3Bucket string, bootstrapS3Key string, VMInit string, BootstrapAgent string) (userdata string, err error) {
-	s3api, err := NewS3Client(clientTimeoutSeconds)
+	s3api, err := NewS3Client()
 	if err != nil {
 		return "", err
 	}

--- a/internal/awsutils/ec2_client_utils.go
+++ b/internal/awsutils/ec2_client_utils.go
@@ -97,7 +97,7 @@ func EC2RunInstancesUtil(
 // Outputs:
 //  userdata: base 64 encoded string with presigned URL to download and initialize the bootstrap agent
 //  err: any error that might occur as part of attempting to generate UserData
-func GenerateVKVMUserData(ctx context.Context, clientTimeoutSeconds int, bootstrapS3Bucket string, bootstrapS3Key string, VMInit string, BootstrapAgent string) (userdata string, err error) {
+func GenerateVKVMUserData(ctx context.Context, bootstrapS3Bucket string, bootstrapS3Key string, VMInit string, BootstrapAgent string) (userdata string, err error) {
 	s3api, err := NewS3Client()
 	if err != nil {
 		return "", err

--- a/internal/awsutils/ec2_client_utils.go
+++ b/internal/awsutils/ec2_client_utils.go
@@ -97,8 +97,8 @@ func EC2RunInstancesUtil(
 // Outputs:
 //  userdata: base 64 encoded string with presigned URL to download and initialize the bootstrap agent
 //  err: any error that might occur as part of attempting to generate UserData
-func GenerateVKVMUserData(ctx context.Context, region string, bootstrapS3Bucket string, bootstrapS3Key string, VMInit string, BootstrapAgent string) (userdata string, err error) {
-	s3api, err := NewS3Client(region)
+func GenerateVKVMUserData(ctx context.Context, clientTimeoutSeconds int, bootstrapS3Bucket string, bootstrapS3Key string, VMInit string, BootstrapAgent string) (userdata string, err error) {
+	s3api, err := NewS3Client(clientTimeoutSeconds)
 	if err != nil {
 		return "", err
 	}

--- a/internal/awsutils/ec2_utils.go
+++ b/internal/awsutils/ec2_utils.go
@@ -174,7 +174,7 @@ func GetInstanceStatusById(instanceId string, ec2Client EC2API) (status string, 
 
 // CreateEC2 generates a new EC2 instance based upon the input values provided.
 func CreateEC2(ctx context.Context, pod *corev1.Pod, clientTimeoutSeconds int, userData string, presignBucket string, presignKey string) (string, error) {
-	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
+	ec2Client, err := NewEc2Client()
 	if err != nil {
 		return "", err
 	}
@@ -248,7 +248,7 @@ func TerminateEC2(ctx context.Context, instanceID string, clientTimeoutSeconds i
 		InstanceIds: []string{instanceID},
 	}
 
-	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
+	ec2Client, err := NewEc2Client()
 
 	resp, err := ec2Client.TerminateInstances(ctx, &terminateInstanceInput)
 	if err != nil {
@@ -295,7 +295,7 @@ func UpdateInstanceSecurityGroups(ctx context.Context, ec2Client EC2API, instanc
 
 // GetPrivateIP gets private ip of the EC2 instance
 func GetPrivateIP(instanceID string, clientTimeoutSeconds int) (privateIp string, err error) {
-	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
+	ec2Client, err := NewEc2Client()
 	if err != nil {
 		return "", err
 	}

--- a/internal/awsutils/ec2_utils.go
+++ b/internal/awsutils/ec2_utils.go
@@ -173,7 +173,7 @@ func GetInstanceStatusById(instanceId string, ec2Client EC2API) (status string, 
 }
 
 // CreateEC2 generates a new EC2 instance based upon the input values provided.
-func CreateEC2(ctx context.Context, pod *corev1.Pod, clientTimeoutSeconds int, userData string, presignBucket string, presignKey string) (string, error) {
+func CreateEC2(ctx context.Context, pod *corev1.Pod, userData string, presignBucket string, presignKey string) (string, error) {
 	ec2Client, err := NewEc2Client()
 	if err != nil {
 		return "", err
@@ -239,7 +239,7 @@ func CreateEC2(ctx context.Context, pod *corev1.Pod, clientTimeoutSeconds int, u
 	return *resp.Instances[0].InstanceId, err
 }
 
-func TerminateEC2(ctx context.Context, instanceID string, clientTimeoutSeconds int) (string, error) {
+func TerminateEC2(ctx context.Context, instanceID string) (string, error) {
 	if instanceID == "" {
 		return "instance-id-not-set", nil
 	}
@@ -294,7 +294,7 @@ func UpdateInstanceSecurityGroups(ctx context.Context, ec2Client EC2API, instanc
 }
 
 // GetPrivateIP gets private ip of the EC2 instance
-func GetPrivateIP(instanceID string, clientTimeoutSeconds int) (privateIp string, err error) {
+func GetPrivateIP(instanceID string) (privateIp string, err error) {
 	ec2Client, err := NewEc2Client()
 	if err != nil {
 		return "", err

--- a/internal/awsutils/ec2_utils.go
+++ b/internal/awsutils/ec2_utils.go
@@ -173,8 +173,8 @@ func GetInstanceStatusById(instanceId string, ec2Client EC2API) (status string, 
 }
 
 // CreateEC2 generates a new EC2 instance based upon the input values provided.
-func CreateEC2(ctx context.Context, pod *corev1.Pod, region string, userData string, presignBucket string, presignKey string) (string, error) {
-	ec2Client, err := NewEc2Client(region)
+func CreateEC2(ctx context.Context, pod *corev1.Pod, clientTimeoutSeconds int, userData string, presignBucket string, presignKey string) (string, error) {
+	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +239,7 @@ func CreateEC2(ctx context.Context, pod *corev1.Pod, region string, userData str
 	return *resp.Instances[0].InstanceId, err
 }
 
-func TerminateEC2(ctx context.Context, instanceID string, region string) (string, error) {
+func TerminateEC2(ctx context.Context, instanceID string, clientTimeoutSeconds int) (string, error) {
 	if instanceID == "" {
 		return "instance-id-not-set", nil
 	}
@@ -248,7 +248,7 @@ func TerminateEC2(ctx context.Context, instanceID string, region string) (string
 		InstanceIds: []string{instanceID},
 	}
 
-	ec2Client, err := NewEc2Client(region)
+	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
 
 	resp, err := ec2Client.TerminateInstances(ctx, &terminateInstanceInput)
 	if err != nil {
@@ -294,8 +294,8 @@ func UpdateInstanceSecurityGroups(ctx context.Context, ec2Client EC2API, instanc
 }
 
 // GetPrivateIP gets private ip of the EC2 instance
-func GetPrivateIP(instanceID string, region string) (privateIp string, err error) {
-	ec2Client, err := NewEc2Client(region)
+func GetPrivateIP(instanceID string, clientTimeoutSeconds int) (privateIp string, err error) {
+	ec2Client, err := NewEc2Client(clientTimeoutSeconds)
 	if err != nil {
 		return "", err
 	}

--- a/internal/awsutils/s3_client.go
+++ b/internal/awsutils/s3_client.go
@@ -12,12 +12,13 @@ package awsutils
 import (
 	"context"
 	"errors"
-	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"time"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	vkconfig "github.com/aws/aws-virtual-kubelet/internal/config"
 	"k8s.io/klog"
 )
 
@@ -28,9 +29,10 @@ type S3Client struct {
 }
 
 // NewS3Client Generates a new S3 Client to be utilized across the program.
-func NewS3Client(clientTimeoutSeconds int) (*S3Client, error) {
+func NewS3Client() (*S3Client, error) {
 	// Initialize client session configuration.
-	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(clientTimeoutSeconds))
+	vkcfg := vkconfig.Config()
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.HealthCheckIntervalSeconds))
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)

--- a/internal/awsutils/s3_client.go
+++ b/internal/awsutils/s3_client.go
@@ -12,6 +12,8 @@ package awsutils
 import (
 	"context"
 	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"time"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -26,9 +28,10 @@ type S3Client struct {
 }
 
 // NewS3Client Generates a new S3 Client to be utilized across the program.
-func NewS3Client(region string) (*S3Client, error) {
+func NewS3Client(clientTimeoutSeconds int) (*S3Client, error) {
 	// Initialize client session configuration.
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(clientTimeoutSeconds))
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)
 		return nil, errors.New("unable to find load SDK config : ")

--- a/internal/awsutils/s3_client.go
+++ b/internal/awsutils/s3_client.go
@@ -32,7 +32,7 @@ type S3Client struct {
 func NewS3Client() (*S3Client, error) {
 	// Initialize client session configuration.
 	vkcfg := vkconfig.Config()
-	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.HealthCheckIntervalSeconds))
+	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds))
 	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithHTTPClient(httpClient))
 	if err != nil {
 		klog.Fatalf("unable to load SDK config, %v", err)

--- a/internal/awsutils/s3_client.go
+++ b/internal/awsutils/s3_client.go
@@ -32,9 +32,9 @@ type S3Client struct {
 // NewS3Client Generates a new S3 Client to be utilized across the program.
 func NewS3Client() (*S3Client, error) {
 	// Initialize client session configuration.
-	//TODO Ideally we should set overall timeout for API, refer to below documentation
-	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/custom-http/
-	//https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
+	// See the following links for an explanation of the timeout options
+	// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/custom-http/
+	// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
 	vkcfg := vkconfig.Config()
 	httpClient := http.NewBuildableClient().WithTimeout(time.Second * time.Duration(vkcfg.AWSClientTimeoutSeconds)).WithDialerOptions(func(d *net.Dialer) {
 		d.KeepAlive = -1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,12 +33,12 @@ type ProviderConfig struct {
 	// Subnet used for... TODO describe how this is used
 	ManagementSubnet string
 
-	VMConfig                   VMConfig       `default:"{}"`
-	BootstrapAgent             BootstrapAgent `default:"{}"`
-	HealthConfig               HealthConfig
-	VKVMAgentConnectionConfig  VkvmaConfig
-	WarmPoolConfig             []WarmPoolConfig `default:"-"`
-	HealthCheckIntervalSeconds int              `default:"60"`
+	VMConfig                  VMConfig       `default:"{}"`
+	BootstrapAgent            BootstrapAgent `default:"{}"`
+	HealthConfig              HealthConfig
+	VKVMAgentConnectionConfig VkvmaConfig
+	WarmPoolConfig            []WarmPoolConfig `default:"-"`
+	AWSClientTimeoutSeconds   int              `default:"30"`
 }
 
 // VMConfig defines Default configurations for EC2 Instances if not otherwise specified.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,12 +33,13 @@ type ProviderConfig struct {
 	// Subnet used for... TODO describe how this is used
 	ManagementSubnet string
 
-	VMConfig                  VMConfig       `default:"{}"`
-	BootstrapAgent            BootstrapAgent `default:"{}"`
-	HealthConfig              HealthConfig
-	VKVMAgentConnectionConfig VkvmaConfig
-	WarmPoolConfig            []WarmPoolConfig `default:"-"`
-	AWSClientTimeoutSeconds   int              `default:"30"`
+	VMConfig                      VMConfig       `default:"{}"`
+	BootstrapAgent                BootstrapAgent `default:"{}"`
+	HealthConfig                  HealthConfig
+	VKVMAgentConnectionConfig     VkvmaConfig
+	WarmPoolConfig                []WarmPoolConfig `default:"-"`
+	AWSClientTimeoutSeconds       int              `default:"10"`
+	AWSClientDialerTimeoutSeconds int              `default:"2"`
 }
 
 // VMConfig defines Default configurations for EC2 Instances if not otherwise specified.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,13 +33,15 @@ type ProviderConfig struct {
 	// Subnet used for... TODO describe how this is used
 	ManagementSubnet string
 
-	VMConfig                      VMConfig       `default:"{}"`
-	BootstrapAgent                BootstrapAgent `default:"{}"`
-	HealthConfig                  HealthConfig
-	VKVMAgentConnectionConfig     VkvmaConfig
-	WarmPoolConfig                []WarmPoolConfig `default:"-"`
-	AWSClientTimeoutSeconds       int              `default:"10"`
-	AWSClientDialerTimeoutSeconds int              `default:"2"`
+	VMConfig                  VMConfig       `default:"{}"`
+	BootstrapAgent            BootstrapAgent `default:"{}"`
+	HealthConfig              HealthConfig
+	VKVMAgentConnectionConfig VkvmaConfig
+	WarmPoolConfig            []WarmPoolConfig `default:"-"`
+	//http client request timeout limit
+	AWSClientTimeoutSeconds int `default:"10"`
+	//http client dialer timeout limit
+	AWSClientDialerTimeoutSeconds int `default:"2"`
 }
 
 // VMConfig defines Default configurations for EC2 Instances if not otherwise specified.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,16 +32,18 @@ type ProviderConfig struct {
 	ClusterName string `default:"aws-virtual-kubelet"`
 	// Subnet used for... TODO describe how this is used
 	ManagementSubnet string
+	// AWS client overall timeout (from request to response)
+	AWSClientTimeoutSeconds int `default:"10"`
+	// AWS client connection timeout (set explicitly to enable faster retries within the overall timeout)
+	AWSClientDialerTimeoutSeconds int `default:"2"`
 
-	VMConfig                  VMConfig       `default:"{}"`
-	BootstrapAgent            BootstrapAgent `default:"{}"`
 	HealthConfig              HealthConfig
 	VKVMAgentConnectionConfig VkvmaConfig
-	WarmPoolConfig            []WarmPoolConfig `default:"-"`
-	//http client request timeout limit
-	AWSClientTimeoutSeconds int `default:"10"`
-	//http client dialer timeout limit
-	AWSClientDialerTimeoutSeconds int `default:"2"`
+
+	// Optional sub-configs
+	VMConfig       VMConfig         `default:"{}"`
+	BootstrapAgent BootstrapAgent   `default:"{}"`
+	WarmPoolConfig []WarmPoolConfig `default:"-"`
 }
 
 // VMConfig defines Default configurations for EC2 Instances if not otherwise specified.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,11 +33,12 @@ type ProviderConfig struct {
 	// Subnet used for... TODO describe how this is used
 	ManagementSubnet string
 
-	VMConfig                  VMConfig       `default:"{}"`
-	BootstrapAgent            BootstrapAgent `default:"{}"`
-	HealthConfig              HealthConfig
-	VKVMAgentConnectionConfig VkvmaConfig
-	WarmPoolConfig            []WarmPoolConfig `default:"-"`
+	VMConfig                   VMConfig       `default:"{}"`
+	BootstrapAgent             BootstrapAgent `default:"{}"`
+	HealthConfig               HealthConfig
+	VKVMAgentConnectionConfig  VkvmaConfig
+	WarmPoolConfig             []WarmPoolConfig `default:"-"`
+	HealthCheckIntervalSeconds int              `default:"60"`
 }
 
 // VMConfig defines Default configurations for EC2 Instances if not otherwise specified.

--- a/internal/ec2provider/compute.go
+++ b/internal/ec2provider/compute.go
@@ -136,7 +136,6 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 	klog.Info("Generating a fresh EC2 Instance")
 	finalUserData, err := awsutils.GenerateVKVMUserData(
 		ctx,
-		cfg.HealthCheckIntervalSeconds,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
 		cfg.VMConfig.InitData,
@@ -146,7 +145,6 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 	instanceID, err := awsutils.CreateEC2(
 		ctx,
 		pod,
-		cfg.HealthCheckIntervalSeconds,
 		finalUserData,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
@@ -158,7 +156,7 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 		return "", "", fmt.Errorf("failed to create ec2 instance, error : %v ", err.Error())
 	}
 
-	privateIP, err := awsutils.GetPrivateIP(instanceID, cfg.HealthCheckIntervalSeconds)
+	privateIP, err := awsutils.GetPrivateIP(instanceID)
 	if err != nil {
 		return "", "", err
 	}
@@ -169,11 +167,10 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 }
 
 func (c *computeManager) deleteCompute(ctx context.Context, pod *corev1.Pod) error {
-	cfg := config.Config()
-
+	
 	podInstanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
-	instanceId, err := awsutils.TerminateEC2(ctx, podInstanceID, cfg.HealthCheckIntervalSeconds)
+	instanceId, err := awsutils.TerminateEC2(ctx, podInstanceID)
 	if err != nil {
 		klog.Errorf("error terminating EC2 instance %v: %v", instanceId, err)
 	}

--- a/internal/ec2provider/compute.go
+++ b/internal/ec2provider/compute.go
@@ -34,21 +34,17 @@ type ComputeManager interface {
 }
 
 type computeManager struct {
-	clientTimeoutSeconds int
-	ec2Client            *awsutils.Client
+	ec2Client *awsutils.Client
 }
 
 func NewComputeManager(ctx context.Context) (*computeManager, error) {
-	cfg := config.Config()
-
-	ec2, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
+	ec2, err := awsutils.NewEc2Client()
 	if err != nil {
 		return nil, err
 	}
 
 	return &computeManager{
-		clientTimeoutSeconds: cfg.HealthCheckIntervalSeconds,
-		ec2Client:            ec2,
+		ec2Client: ec2,
 	}, nil
 }
 
@@ -96,13 +92,11 @@ func (c *computeManager) GetCompute(ctx context.Context, p *Ec2Provider, pod *co
 }
 
 func (c *computeManager) podHasInstance(ctx context.Context, pod *corev1.Pod) bool {
-	cfg := config.Config()
-
 	podInstanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
 	// if we already created an instance for this pod (in which case the instance-id annotation will be set)
 	if podInstanceID != "" {
-		ec2Client, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
+		ec2Client, err := awsutils.NewEc2Client()
 		if err != nil {
 			// if we get an error trying to create an Ec2 client, assume we don't have a valid instance
 			return false

--- a/internal/ec2provider/compute.go
+++ b/internal/ec2provider/compute.go
@@ -34,22 +34,21 @@ type ComputeManager interface {
 }
 
 type computeManager struct {
-	region    string
-	ec2Client *awsutils.Client
+	clientTimeoutSeconds int
+	ec2Client            *awsutils.Client
 }
 
 func NewComputeManager(ctx context.Context) (*computeManager, error) {
 	cfg := config.Config()
-	region := cfg.Region
 
-	ec2, err := awsutils.NewEc2Client(region)
+	ec2, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
 	if err != nil {
 		return nil, err
 	}
 
 	return &computeManager{
-		region:    region,
-		ec2Client: ec2,
+		clientTimeoutSeconds: cfg.HealthCheckIntervalSeconds,
+		ec2Client:            ec2,
 	}, nil
 }
 
@@ -98,13 +97,12 @@ func (c *computeManager) GetCompute(ctx context.Context, p *Ec2Provider, pod *co
 
 func (c *computeManager) podHasInstance(ctx context.Context, pod *corev1.Pod) bool {
 	cfg := config.Config()
-	region := cfg.Region
 
 	podInstanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
 	// if we already created an instance for this pod (in which case the instance-id annotation will be set)
 	if podInstanceID != "" {
-		ec2Client, err := awsutils.NewEc2Client(region)
+		ec2Client, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
 		if err != nil {
 			// if we get an error trying to create an Ec2 client, assume we don't have a valid instance
 			return false
@@ -144,7 +142,7 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 	klog.Info("Generating a fresh EC2 Instance")
 	finalUserData, err := awsutils.GenerateVKVMUserData(
 		ctx,
-		cfg.Region,
+		cfg.HealthCheckIntervalSeconds,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
 		cfg.VMConfig.InitData,
@@ -154,7 +152,7 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 	instanceID, err := awsutils.CreateEC2(
 		ctx,
 		pod,
-		cfg.Region,
+		cfg.HealthCheckIntervalSeconds,
 		finalUserData,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
@@ -166,7 +164,7 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 		return "", "", fmt.Errorf("failed to create ec2 instance, error : %v ", err.Error())
 	}
 
-	privateIP, err := awsutils.GetPrivateIP(instanceID, cfg.Region)
+	privateIP, err := awsutils.GetPrivateIP(instanceID, cfg.HealthCheckIntervalSeconds)
 	if err != nil {
 		return "", "", err
 	}
@@ -178,11 +176,10 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 
 func (c *computeManager) deleteCompute(ctx context.Context, pod *corev1.Pod) error {
 	cfg := config.Config()
-	region := cfg.Region
 
 	podInstanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
-	instanceId, err := awsutils.TerminateEC2(ctx, podInstanceID, region)
+	instanceId, err := awsutils.TerminateEC2(ctx, podInstanceID, cfg.HealthCheckIntervalSeconds)
 	if err != nil {
 		klog.Errorf("error terminating EC2 instance %v: %v", instanceId, err)
 	}

--- a/internal/ec2provider/compute.go
+++ b/internal/ec2provider/compute.go
@@ -167,7 +167,7 @@ func (c *computeManager) createCompute(ctx context.Context, pod *corev1.Pod) (st
 }
 
 func (c *computeManager) deleteCompute(ctx context.Context, pod *corev1.Pod) error {
-	
+
 	podInstanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
 	instanceId, err := awsutils.TerminateEC2(ctx, podInstanceID)

--- a/internal/ec2provider/eninode.go
+++ b/internal/ec2provider/eninode.go
@@ -39,11 +39,10 @@ type EniNode struct {
 
 func GetOrCreateEniNode(ctx context.Context) (*EniNode, error) {
 	cfg := config.Config()
-	clientTimeoutSeconds := cfg.HealthCheckIntervalSeconds
 	clusterName := cfg.ClusterName
 	subnetId := cfg.ManagementSubnet
 
-	ec2Client, err := awsutils.NewEc2Client(clientTimeoutSeconds)
+	ec2Client, err := awsutils.NewEc2Client()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ec2provider/eninode.go
+++ b/internal/ec2provider/eninode.go
@@ -39,11 +39,11 @@ type EniNode struct {
 
 func GetOrCreateEniNode(ctx context.Context) (*EniNode, error) {
 	cfg := config.Config()
-	region := cfg.Region
+	clientTimeoutSeconds := cfg.HealthCheckIntervalSeconds
 	clusterName := cfg.ClusterName
 	subnetId := cfg.ManagementSubnet
 
-	ec2Client, err := awsutils.NewEc2Client(region)
+	ec2Client, err := awsutils.NewEc2Client(clientTimeoutSeconds)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ec2provider/warmpool.go
+++ b/internal/ec2provider/warmpool.go
@@ -70,11 +70,10 @@ type WarmPoolManager struct {
 
 func NewWarmPool(ctx context.Context, provider *Ec2Provider) (*WarmPoolManager, error) {
 	cfg := config.Config()
-	region := cfg.Region
 
 	klog.Infof("Creating Warm Pool Manager with config '%+v'", cfg.WarmPoolConfig)
 
-	ec2Client, err := awsutils.NewEc2Client(region)
+	ec2Client, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
 	if err != nil {
 		klog.Errorf("Can't create Ec2 client in Warm Pool init: %v", err)
 		return nil, err
@@ -222,7 +221,7 @@ func (wpm *WarmPoolManager) CreateWarmEC2(ctx context.Context, wpConfig config.W
 
 	finalUserData, err := awsutils.GenerateVKVMUserData(
 		ctx,
-		cfg.Region,
+		cfg.HealthCheckIntervalSeconds,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
 		cfg.VMConfig.InitData,
@@ -410,9 +409,8 @@ func (wpm *WarmPoolManager) GetWarmPoolInstanceIfExist(ctx context.Context) (ins
 // To be explicitly used for Warmpool Management and prefer DeletePod once a Pod is set.
 func (wpm *WarmPoolManager) TerminateInstance(ctx context.Context, instanceID string) (resp string, err error) {
 	cfg := config.Config()
-	region := cfg.Region
 
-	resp, err = awsutils.TerminateEC2(ctx, instanceID, region)
+	resp, err = awsutils.TerminateEC2(ctx, instanceID, cfg.HealthCheckIntervalSeconds)
 	return resp, err
 }
 

--- a/internal/ec2provider/warmpool.go
+++ b/internal/ec2provider/warmpool.go
@@ -221,7 +221,6 @@ func (wpm *WarmPoolManager) CreateWarmEC2(ctx context.Context, wpConfig config.W
 
 	finalUserData, err := awsutils.GenerateVKVMUserData(
 		ctx,
-		cfg.HealthCheckIntervalSeconds,
 		cfg.BootstrapAgent.S3Bucket,
 		cfg.BootstrapAgent.S3Key,
 		cfg.VMConfig.InitData,
@@ -408,9 +407,8 @@ func (wpm *WarmPoolManager) GetWarmPoolInstanceIfExist(ctx context.Context) (ins
 //TerminateInstance provides a way to terminate an EC2 instance.
 // To be explicitly used for Warmpool Management and prefer DeletePod once a Pod is set.
 func (wpm *WarmPoolManager) TerminateInstance(ctx context.Context, instanceID string) (resp string, err error) {
-	cfg := config.Config()
 
-	resp, err = awsutils.TerminateEC2(ctx, instanceID, cfg.HealthCheckIntervalSeconds)
+	resp, err = awsutils.TerminateEC2(ctx, instanceID)
 	return resp, err
 }
 

--- a/internal/ec2provider/warmpool.go
+++ b/internal/ec2provider/warmpool.go
@@ -73,7 +73,7 @@ func NewWarmPool(ctx context.Context, provider *Ec2Provider) (*WarmPoolManager, 
 
 	klog.Infof("Creating Warm Pool Manager with config '%+v'", cfg.WarmPoolConfig)
 
-	ec2Client, err := awsutils.NewEc2Client(cfg.HealthCheckIntervalSeconds)
+	ec2Client, err := awsutils.NewEc2Client()
 	if err != nil {
 		klog.Errorf("Can't create Ec2 client in Warm Pool init: %v", err)
 		return nil, err

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -164,7 +164,7 @@ func checkEc2Status(ctx context.Context, m *Monitor) *checkResult {
 
 	instanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
-	ec2Client, err := awsutils.NewEc2Client("us-west-2")
+	ec2Client, err := awsutils.NewEc2Client(config.ProviderConfig{}.HealthCheckIntervalSeconds)
 	if err != nil {
 		return NewCheckResult(m, true, err.Error(), nil)
 	}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -164,7 +164,7 @@ func checkEc2Status(ctx context.Context, m *Monitor) *checkResult {
 
 	instanceID := pod.Annotations["compute.amazonaws.com/instance-id"]
 
-	ec2Client, err := awsutils.NewEc2Client(config.ProviderConfig{}.HealthCheckIntervalSeconds)
+	ec2Client, err := awsutils.NewEc2Client()
 	if err != nil {
 		return NewCheckResult(m, true, err.Error(), nil)
 	}

--- a/internal/vkvmaclient/vkvmaclient.go
+++ b/internal/vkvmaclient/vkvmaclient.go
@@ -141,7 +141,7 @@ func (v *VkvmaClient) Connect(ctx context.Context) (*grpc.ClientConn, error) {
 
 	select {
 	case <-time.After(1 * time.Second):
-		klog.Fatalf("connecting to %v pending...(%v timeout)", dialAddr, timeout)
+		klog.Errorf("connecting to %v pending...(%v timeout)", dialAddr, timeout)
 	case <-ctx.Done():
 		err := ctx.Err()
 		connDuration := time.Since(connStart)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added connection timeout http config to ec2 and s3 clients.
Added new parameter to config-map with 30 second default value HttpClientTimeoutSeconds

**Testing** :

- Deploy VK
- Deploy a sample Pod spec
- EC2 instance should be created successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.