### PR TITLE
Add validation check for desired count in warmpool config

### DIFF
--- a/internal/config/loaders.go
+++ b/internal/config/loaders.go
@@ -107,6 +107,9 @@ func validateWarmPoolConfig(pc *ProviderConfig, errs []string) []string {
 			if len(wpc.Subnets) == 0 {
 				errs = append(errs, fmt.Sprintf("WarmPoolConfig.Subnets can't be empty for WarmPoolConfig[%d]", i))
 			}
+			if wpc.DesiredCount <= 0 {
+				errs = append(errs, fmt.Sprintf("WarmPoolConfig.DesiredCount can't be zero or negative[%d]", i))
+			}
 		}
 	}
 	return errs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`DesiredCount` parameter in the WarmPool config should be a positive integer. A zero or negative integer as the desired count of the warmpool instances is invalid. 

This PR adds a validation check in the config loader to validate that the `DesiredCount` is a positive integer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
